### PR TITLE
Split recipe descriptions into sentence pairs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -306,6 +306,11 @@ summary::-webkit-details-marker {
 
 .recipe-description .pl-desc {
   color: var(--color-red);
+  font-style: italic;
+}
+
+.recipe-description .desc-pair {
+  margin-bottom: 0.5em;
 }
 
 /* Game controls */

--- a/js/recipes.js
+++ b/js/recipes.js
@@ -224,11 +224,37 @@ function displayRecipes() {
         }
       }
       if (itDesc && plDesc) {
-        const descP = document.createElement('p');
-        descP.className = 'recipe-description';
-        // Use data-desc attribute to store Italian text for TTS if needed
-        descP.innerHTML = `<em>Przygotowanie:</em> <span class="it-desc" data-text="${itDesc}">${itDesc}</span><br><span class="pl-desc">${plDesc}</span>`;
-        contentDiv.appendChild(descP);
+        const descDiv = document.createElement('div');
+        descDiv.className = 'recipe-description';
+
+        const prepLabel = document.createElement('em');
+        prepLabel.textContent = 'Przygotowanie:';
+        descDiv.appendChild(prepLabel);
+
+        const itSentences = itDesc.match(/[^.!?]+[.!?]+/g) || [itDesc];
+        const plSentences = plDesc.match(/[^.!?]+[.!?]+/g) || [plDesc];
+
+        itSentences.forEach((itSentence, idx) => {
+          const pair = document.createElement('div');
+          pair.className = 'desc-pair';
+
+          const itSpan = document.createElement('span');
+          itSpan.className = 'it-desc';
+          itSpan.dataset.text = itSentence.trim();
+          itSpan.textContent = itSentence.trim();
+          pair.appendChild(itSpan);
+
+          pair.appendChild(document.createElement('br'));
+
+          const plSpan = document.createElement('span');
+          plSpan.className = 'pl-desc';
+          plSpan.textContent = (plSentences[idx] || '').trim();
+          pair.appendChild(plSpan);
+
+          descDiv.appendChild(pair);
+        });
+
+        contentDiv.appendChild(descDiv);
       }
 
       // If the recipe has a photo defined, display it under the description.


### PR DESCRIPTION
## Summary
- Render recipe descriptions as sentence pairs with Italian and Polish lines
- Style Polish translations in italics and add spacing between pairs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689b6e64d1d0833089aaa1a764aeb6f2