### PR TITLE
Add pizza, bread, rice and vegetable categories

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1114,7 +1114,7 @@
     "id": 36,
     "italian_name": "Risotto alla Milanese",
     "polish_name": "Risotto alla Milanese",
-    "category": "ryż",
+    "category": "risotto",
     "ingredients": [
       {
         "it": "riso arborio",
@@ -1151,7 +1151,7 @@
     "id": 37,
     "italian_name": "Risotto ai funghi porcini",
     "polish_name": "Risotto z borowikami",
-    "category": "ryż",
+    "category": "risotto",
     "ingredients": [
       {
         "it": "riso arborio",
@@ -1188,7 +1188,7 @@
     "id": 38,
     "italian_name": "Risotto al nero di seppia",
     "polish_name": "Risotto z atramentem kałamarnicy",
-    "category": "ryż",
+    "category": "risotto",
     "ingredients": [
       {
         "it": "riso arborio",
@@ -1225,7 +1225,7 @@
     "id": 39,
     "italian_name": "Risotto ai frutti di mare",
     "polish_name": "Risotto z owocami morza",
-    "category": "ryż",
+    "category": "risotto",
     "ingredients": [
       {
         "it": "riso arborio",

--- a/js/recipes.js
+++ b/js/recipes.js
@@ -10,7 +10,10 @@ const categoryLabels = {
   'mięso': 'MIĘSO',
   'ryby': 'RYBY',
   'przystawka': 'PRZYSTAWKI',
-  'deser': 'DESERY'
+  'deser': 'DESERY',
+  'pizza': 'PIZZA',
+  'pieczywo': 'PIECZYWO',
+  'warzywa': 'WARZYWA'
 };
 
 // Mapping of category codes to image file names located in images/categories
@@ -21,7 +24,10 @@ const categoryImages = {
   'mięso': 'categories/mieso.png',
   'ryby': 'categories/ryby.png',
   'przystawka': 'categories/przystawka.png',
-  'deser': 'categories/deser.png'
+  'deser': 'categories/deser.png',
+  'pizza': 'categories/pizza.png',
+  'pieczywo': 'categories/pieczywo.png',
+  'warzywa': 'categories/warzywa.png'
 };
 
 // Generic cooking instructions per category in Italian and Polish. Placeholders

--- a/recipes.html
+++ b/recipes.html
@@ -42,6 +42,9 @@
             <option value="ryby">Ryby</option>
             <option value="przystawka">Przystawki</option>
             <option value="deser">Desery</option>
+            <option value="pizza">Pizza</option>
+            <option value="pieczywo">Pieczywo</option>
+            <option value="warzywa">Warzywa</option>
           </select>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- extend category label and image maps with pizza, pieczywo and warzywa
- expose new categories in recipe filter
- align recipe data to use `risotto` instead of `ryż`

## Testing
- `node - <<'NODE'
const fs=require('fs');
const data=JSON.parse(fs.readFileSync('data/recipes.json','utf8'));
const categories = new Set(['pasta','risotto','zupa','mięso','ryby','przystawka','deser','pizza','pieczywo','warzywa']);
const missing = data.filter(r => !categories.has(r.category));
console.log('count', data.length);
console.log('unique categories', [...new Set(data.map(r=>r.category))].sort());
console.log('missing categories', missing.length);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_689bb0f36ab08330bb3e527f4c396636