### PR TITLE
Prefix recipe titles with IDs

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -195,10 +195,10 @@ function displayRecipes() {
 
       const summaryEl = document.createElement('summary');
       summaryEl.className = 'recipe-summary';
-      // Create a title span containing Italian and Polish names. We no longer
-      // display images on individual recipe rows; only category headers have images.
+      // Create a title span containing the recipe number, Italian name and Polish name.
+      // We no longer display images on individual recipe rows; only category headers have images.
       const titleSpan = document.createElement('span');
-      titleSpan.innerHTML = `<strong>${recipe.italian_name}</strong> / ${recipe.polish_name}`;
+      titleSpan.innerHTML = `<strong>${recipe.id}. ${recipe.italian_name}</strong> / ${recipe.polish_name}`;
       summaryEl.appendChild(titleSpan);
       detailsEl.appendChild(summaryEl);
 


### PR DESCRIPTION
## Summary
- Prefix each recipe title with its numeric ID for clearer reference.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689bb928bb288330be51328065122560