### PR TITLE
Handle missing localStorage for Italian voice

### DIFF
--- a/js/recipes.js
+++ b/js/recipes.js
@@ -97,7 +97,12 @@ function loadItalianVoice(callback) {
       return;
     }
     // Try to load saved voice from localStorage
-    const savedName = localStorage.getItem('bella_it_voice');
+    let savedName = null;
+    try {
+      savedName = localStorage.getItem('bella_it_voice');
+    } catch (e) {
+      console.warn('localStorage unavailable, cannot load voice preference:', e);
+    }
     let chosen = null;
     if (savedName) {
       chosen = voices.find(v => v.name === savedName);
@@ -107,7 +112,11 @@ function loadItalianVoice(callback) {
     }
     ITALIAN_VOICE = chosen;
     if (chosen) {
-      localStorage.setItem('bella_it_voice', chosen.name);
+      try {
+        localStorage.setItem('bella_it_voice', chosen.name);
+      } catch (e) {
+        console.warn('localStorage unavailable, cannot save voice preference:', e);
+      }
     }
     callback(chosen);
   };


### PR DESCRIPTION
## Summary
- Protect Italian voice selection logic from failing when `localStorage` is unavailable.

## Testing
- `node --check js/recipes.js`


------
https://chatgpt.com/codex/tasks/task_e_689bbd113b1c8325bd1856105d704283