### PR TITLE
Remove personal names and add player registration

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -333,6 +333,30 @@ summary::-webkit-details-marker {
   cursor: pointer;
 }
 
+.player-select .add-player {
+  margin-top: 10px;
+}
+
+.player-select input[type='text'] {
+  padding: 5px;
+  margin-right: 10px;
+}
+
+.player-select button {
+  background-color: var(--color-green);
+  color: var(--color-white);
+  border: none;
+  padding: 6px 12px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease;
+}
+
+.player-select button:hover {
+  background-color: #007735;
+}
+
 .game-select {
   display: flex;
   gap: 15px;

--- a/game.html
+++ b/game.html
@@ -28,14 +28,11 @@
       </div>
       <section class="game-controls">
         <div class="player-select">
-          <label>
-            <input type="radio" name="current-player" value="Kasia" checked />
-            Kasia
-          </label>
-          <label>
-            <input type="radio" name="current-player" value="Michał" />
-            Michał
-          </label>
+          <div id="player-options"></div>
+          <div class="add-player">
+            <input type="text" id="new-player-name" placeholder="Twój nick" />
+            <button id="add-player-btn">Dołącz</button>
+          </div>
         </div>
         <div class="game-select">
           <button class="game-btn" data-game="memory">Gra pamięciowa</button>

--- a/index.html
+++ b/index.html
@@ -20,17 +20,17 @@
     </header>
     <section class="page-title container">
       <h1>Bella Cucina</h1>
-      <p class="tagline">Nauka gotowania i języka włoskiego dla Kasi i Michała</p>
+      <p class="tagline">Ucz się języka włoskiego i poznawaj smaki Italii</p>
     </section>
 
     <main class="container">
       <section class="intro">
         <p>
-          Witajcie, Kasia i Michał! Ten serwis łączy miłość do gotowania z pasją do
-          języka włoskiego. Znajdziecie tutaj ponad sto przepisów, które zabiorą
-          Was w podróż po włoskich regionach i pozwolą nauczyć się nazw składników
-          zarówno po polsku, jak i po włosku. Dzięki grom utrwalicie słownictwo,
-          a przy okazji będziecie rywalizować o miano najlepszego szefa kuchni!
+          Witaj! Ten serwis łączy miłość do gotowania z pasją do języka włoskiego.
+          Znajdziesz tutaj ponad sto przepisów, które zabiorą Cię w podróż po
+          włoskich regionach i pozwolą nauczyć się nazw składników zarówno po
+          polsku, jak i po włosku. Dzięki grom utrwalisz słownictwo i będziesz
+          rywalizować o miano najlepszego szefa kuchni!
         </p>
       </section>
 
@@ -62,8 +62,8 @@
 
     <footer>
       <p>
-        &copy; 2025 Bella Cucina – Stworzone specjalnie dla Kasi i Michała. Powodzenia
-        w nauce i smacznego!
+        &copy; 2025 Bella Cucina – Ucz się włoskiego i odkrywaj smak Italii.
+        Powodzenia w nauce i smacznego!
       </p>
     </footer>
 

--- a/js/game.js
+++ b/js/game.js
@@ -2,7 +2,7 @@
 
 let recipesData = [];
 let ingredientsPairs = [];
-let currentPlayer = 'Kasia';
+let currentPlayer = null;
 
 // Utility: shuffle array
 function shuffle(arr) {
@@ -32,6 +32,7 @@ function initGameData() {
 
 // Scoreboard helper: add points to current player
 function addPoints(points) {
+  if (!currentPlayer) return;
   const scores = loadScores();
   scores[currentPlayer] = (scores[currentPlayer] || 0) + points;
   saveScores(scores);
@@ -41,7 +42,33 @@ function addPoints(points) {
 // Set current player from radio input
 function updateCurrentPlayer() {
   const selected = document.querySelector('input[name="current-player"]:checked');
-  currentPlayer = selected ? selected.value : 'Kasia';
+  if (selected) {
+    currentPlayer = selected.value;
+  }
+}
+
+// Render player selection options
+function renderPlayerOptions() {
+  const container = document.getElementById('player-options');
+  if (!container) return;
+  const scores = loadScores();
+  const players = Object.keys(scores);
+  container.innerHTML = '';
+  players.forEach((player, idx) => {
+    const label = document.createElement('label');
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'current-player';
+    radio.value = player;
+    if ((currentPlayer === null && idx === 0) || currentPlayer === player) {
+      radio.checked = true;
+      currentPlayer = player;
+    }
+    radio.addEventListener('change', updateCurrentPlayer);
+    label.appendChild(radio);
+    label.appendChild(document.createTextNode(player));
+    container.appendChild(label);
+  });
 }
 
 // Initialize game page after recipe data has been loaded via fetch.
@@ -49,6 +76,7 @@ function updateCurrentPlayer() {
 window.initGamePage = function () {
   renderScoreboard();
   initGameData();
+  renderPlayerOptions();
   // Game buttons
   document.querySelectorAll('.game-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -63,10 +91,20 @@ window.initGamePage = function () {
       }
     });
   });
-  // listen for player change
-  document.querySelectorAll('input[name="current-player"]').forEach((radio) => {
-    radio.addEventListener('change', updateCurrentPlayer);
-  });
+
+  const addBtn = document.getElementById('add-player-btn');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      const input = document.getElementById('new-player-name');
+      const name = input.value.trim();
+      if (name) {
+        addPlayer(name);
+        currentPlayer = name;
+        renderPlayerOptions();
+        input.value = '';
+      }
+    });
+  }
 };
 
 // MEMORY GAME

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 // Global scoreboard management for Bella Cucina
 
 // Prosta pamięć rezerwowa, gdy localStorage jest niedostępne
-let memoryScores = { Kasia: 0, Michał: 0 };
+let memoryScores = {};
 let storageAvailable = true;
 
 // Load scores from localStorage or initialize default
@@ -11,23 +11,18 @@ function loadScores() {
       const stored = localStorage.getItem('bellaScores');
       if (stored) {
         try {
-          const parsed = JSON.parse(stored);
-          // ensure both players exist
-          memoryScores = {
-            Kasia: parsed.Kasia ?? 0,
-            Michał: parsed['Michał'] ?? 0,
-          };
+          memoryScores = JSON.parse(stored) || {};
         } catch (e) {
           console.error('Błąd odczytu punktów:', e);
-          memoryScores = { Kasia: 0, Michał: 0 };
+          memoryScores = {};
         }
       } else {
-        memoryScores = { Kasia: 0, Michał: 0 };
+        memoryScores = {};
       }
     } catch (e) {
       console.error('localStorage niedostępne, używam wartości domyślnych:', e);
       storageAvailable = false;
-      memoryScores = { Kasia: 0, Michał: 0 };
+      memoryScores = {};
     }
   }
   return memoryScores;
@@ -54,7 +49,7 @@ function renderScoreboard() {
   // Clear current contents
   scoreboardEl.innerHTML = '';
   // Create player elements
-  ['Kasia', 'Michał'].forEach((player) => {
+  Object.keys(scores).forEach((player) => {
     const playerDiv = document.createElement('div');
     playerDiv.className = 'player';
     const nameEl = document.createElement('h3');
@@ -70,9 +65,20 @@ function renderScoreboard() {
 
 // Reset scores to zero
 function resetScores() {
-  const scores = { Kasia: 0, Michał: 0 };
+  const scores = loadScores();
+  Object.keys(scores).forEach((p) => (scores[p] = 0));
   saveScores(scores);
   renderScoreboard();
+}
+
+// Add a new player with zero points
+function addPlayer(name) {
+  const scores = loadScores();
+  if (!scores[name]) {
+    scores[name] = 0;
+    saveScores(scores);
+    renderScoreboard();
+  }
 }
 
 // Initialize scoreboard and buttons when DOM is ready


### PR DESCRIPTION
## Summary
- Rewrite site descriptions to focus on learning Italian and exploring its cuisine, removing personal mentions.
- Introduce nickname-based player registration and selection for games.
- Refactor scoreboard logic for dynamic players with updated styling.

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c3d34fe48833090c3f3d5bade78c5