### PR TITLE
Show leaderboard only in game area and add graphic game buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -364,19 +364,31 @@ summary::-webkit-details-marker {
   justify-content: center;
 }
 
-.game-btn {
-  background-color: var(--color-green);
-  color: var(--color-white);
-  border: none;
-  padding: 10px 15px;
-  border-radius: 5px;
+.game-card {
+  background-color: var(--color-white);
+  border-radius: 10px;
+  box-shadow: 0 2px 5px var(--card-shadow);
+  padding: 20px;
+  width: 200px;
+  text-align: center;
   cursor: pointer;
-  font-size: 0.95rem;
-  transition: background-color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.game-btn:hover {
-  background-color: #007735;
+.game-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 10px var(--card-shadow);
+}
+
+.game-card .icon {
+  font-size: 2rem;
+  margin-bottom: 10px;
+  color: var(--color-red);
+}
+
+.game-card h3 {
+  font-size: 1.2rem;
+  color: var(--color-green);
 }
 
 /* Memory game grid */

--- a/game.html
+++ b/game.html
@@ -35,9 +35,18 @@
           </div>
         </div>
         <div class="game-select">
-          <button class="game-btn" data-game="memory">Gra pamięciowa</button>
-          <button class="game-btn" data-game="ingredients">Dobierz składniki</button>
-          <button class="game-btn" data-game="translation">Tłumaczenie</button>
+          <div class="game-card" data-game="memory">
+            <div class="icon"><i class="fas fa-brain"></i></div>
+            <h3>Gra pamięciowa</h3>
+          </div>
+          <div class="game-card" data-game="ingredients">
+            <div class="icon"><i class="fas fa-carrot"></i></div>
+            <h3>Dobierz składniki</h3>
+          </div>
+          <div class="game-card" data-game="translation">
+            <div class="icon"><i class="fas fa-language"></i></div>
+            <h3>Tłumaczenie</h3>
+          </div>
         </div>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -34,10 +34,6 @@
         </p>
       </section>
 
-      <section class="scoreboard" id="scoreboard">
-        <!-- scoreboard content is inserted via JavaScript -->
-      </section>
-
       <section class="actions">
         <div class="card">
           <a href="recipes.html">

--- a/js/game.js
+++ b/js/game.js
@@ -78,7 +78,7 @@ window.initGamePage = function () {
   initGameData();
   renderPlayerOptions();
   // Game buttons
-  document.querySelectorAll('.game-btn').forEach((btn) => {
+  document.querySelectorAll('.game-card').forEach((btn) => {
     btn.addEventListener('click', () => {
       updateCurrentPlayer();
       const game = btn.getAttribute('data-game');


### PR DESCRIPTION
## Summary
- Remove player scoreboard from the home page so ranking appears only in the game area.
- Replace text game selectors with styled graphic cards representing each game.
- Add CSS and JS support for new game selection cards.

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c41c903e48330a3b58bfe91d888a0