### PR TITLE
Hide game menu on mobile and tidy homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -214,6 +214,22 @@ h1, h2 {
   background-color: #b71d2b;
 }
 
+/* Generic button used in games (e.g., exit to menu) */
+.submit-btn {
+  margin-top: 15px;
+  background-color: var(--color-green);
+  color: var(--color-white);
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.submit-btn:hover {
+  background-color: #007735;
+}
+
 footer {
   text-align: center;
   padding: 20px;

--- a/index.html
+++ b/index.html
@@ -18,10 +18,7 @@
     <header class="hero">
       <img src="images/start1.jpg" alt="Grafika startowa Bella Cucina" class="hero-img" />
     </header>
-    <section class="page-title container">
-      <h1>Bella Cucina</h1>
-      <p class="tagline">Ucz się języka włoskiego i poznawaj smaki Italii</p>
-    </section>
+
 
     <main class="container">
       <section class="intro">

--- a/js/game.js
+++ b/js/game.js
@@ -71,6 +71,44 @@ function renderPlayerOptions() {
   });
 }
 
+// Show/hide game menu for mobile-friendly gameplay
+function hideGameMenu() {
+  const controls = document.querySelector('.game-controls');
+  const scoreboard = document.getElementById('scoreboard');
+  const backLink = document.querySelector('.back-link');
+  const hero = document.querySelector('.hero');
+  const pageTitle = document.querySelector('.page-title');
+  if (controls) controls.style.display = 'none';
+  if (scoreboard) scoreboard.style.display = 'none';
+  if (backLink) backLink.style.display = 'none';
+  if (hero) hero.style.display = 'none';
+  if (pageTitle) pageTitle.style.display = 'none';
+}
+
+function showGameMenu() {
+  const controls = document.querySelector('.game-controls');
+  const scoreboard = document.getElementById('scoreboard');
+  const backLink = document.querySelector('.back-link');
+  const hero = document.querySelector('.hero');
+  const pageTitle = document.querySelector('.page-title');
+  if (controls) controls.style.display = '';
+  if (scoreboard) scoreboard.style.display = '';
+  if (backLink) backLink.style.display = '';
+  if (hero) hero.style.display = '';
+  if (pageTitle) pageTitle.style.display = '';
+  const container = document.getElementById('game-container');
+  if (container) container.innerHTML = '';
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function addExitButton(container) {
+  const exitBtn = document.createElement('button');
+  exitBtn.className = 'submit-btn';
+  exitBtn.textContent = 'Powrót do menu';
+  exitBtn.addEventListener('click', showGameMenu);
+  container.appendChild(exitBtn);
+}
+
 // Initialize game page after recipe data has been loaded via fetch.
 // Called from game.html once `window.recipesData` is available.
 window.initGamePage = function () {
@@ -81,6 +119,7 @@ window.initGamePage = function () {
   document.querySelectorAll('.game-card').forEach((btn) => {
     btn.addEventListener('click', () => {
       updateCurrentPlayer();
+      hideGameMenu();
       const game = btn.getAttribute('data-game');
       if (game === 'memory') {
         startMemoryGame();
@@ -156,6 +195,8 @@ function startMemoryGame() {
     grid.appendChild(card);
   });
 
+  addExitButton(container);
+
   function revealCard(card) {
     card.classList.add('revealed');
     card.textContent = card.dataset.text;
@@ -192,7 +233,7 @@ function startMemoryGame() {
         if (matchedCount === numPairs) {
           setTimeout(() => {
             alert('Brawo! Ukończyłeś grę.');
-            startMemoryGame();
+            showGameMenu();
           }, 200);
         }
       }, 300);
@@ -281,6 +322,7 @@ function newIngredientRound(container) {
   wrapper.appendChild(submit);
   container.innerHTML = '';
   container.appendChild(wrapper);
+  addExitButton(container);
 }
 
 function evaluateIngredientRound(wrapper, options) {
@@ -383,6 +425,7 @@ function newTranslationRound(container) {
   wrapper.appendChild(answersDiv);
   container.innerHTML = '';
   container.appendChild(wrapper);
+  addExitButton(container);
 
   // We intentionally do not attach pronunciation to the Italian word
   // in the question for the translation game to prevent interfering with


### PR DESCRIPTION
## Summary
- Remove hero title and tagline from the homepage for a cleaner landing screen.
- Hide game menus and header elements when a game starts, showing only game content.
- Add a reusable exit button so players can return to the game selection menu on mobile.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c44dc5fd48330a1293448991f01fa