### PR TITLE
feat: enhance translation game layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -495,6 +495,18 @@ summary::-webkit-details-marker {
 /* Translation game */
 .translation-game {
   margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.translation-game .flags {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2rem;
+  gap: 8px;
+  margin-bottom: 10px;
 }
 
 .translation-game .question {
@@ -503,11 +515,22 @@ summary::-webkit-details-marker {
   text-align: center;
 }
 
+.translation-game .word-box {
+  border: 1px solid var(--color-green);
+  background-color: #f0f0f0;
+  color: var(--color-green);
+  font-size: 1.35rem;
+  padding: 16px 26px;
+  text-align: center;
+  margin: 20px 0;
+  border-radius: 4px;
+}
+
 .translation-game .answers {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 10px;
-  justify-content: center;
+  align-items: center;
 }
 
 .translation-game .answer-btn {
@@ -554,6 +577,20 @@ summary::-webkit-details-marker {
 }
 .translation-game .submit-btn:hover {
   background-color: #007735;
+}
+
+.exit-btn {
+  margin-top: 20px;
+  background-color: #cccccc;
+  color: #333333;
+  border: none;
+  padding: 16px 32px;
+  font-size: 1.35rem;
+  border-radius: 4px;
+  cursor: pointer;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* Subpage controls */

--- a/js/game.js
+++ b/js/game.js
@@ -103,7 +103,7 @@ function showGameMenu() {
 
 function addExitButton(container) {
   const exitBtn = document.createElement('button');
-  exitBtn.className = 'submit-btn';
+  exitBtn.className = 'exit-btn';
   exitBtn.textContent = 'Powrót do menu';
   exitBtn.addEventListener('click', showGameMenu);
   container.appendChild(exitBtn);
@@ -377,15 +377,16 @@ function newTranslationRound(container) {
   const pair = ingredientsPairs[Math.floor(Math.random() * ingredientsPairs.length)];
   // Decide direction: 50% Italian->Polish, 50% Polish->Italian
   const direction = Math.random() < 0.5 ? 'it2pl' : 'pl2it';
-  let questionText, correctAnswer;
+  let questionWord, instructionText, correctAnswer;
   if (direction === 'it2pl') {
-    // For Italian→Polish, ask to translate the Italian word. We do not wrap
-    // the word in a clickable span anymore to avoid interfering with game flow.
-    questionText = `Jak przetłumaczyć na polski: ${pair.it}?`;
+    // Italian → Polish
+    questionWord = pair.it;
+    instructionText = 'Przetłumacz na polski:';
     correctAnswer = pair.pl;
   } else {
-    // For Polish→Italian, ask to translate the Polish word.
-    questionText = `Jak przetłumaczyć na włoski: ${pair.pl}?`;
+    // Polish → Italian
+    questionWord = pair.pl;
+    instructionText = 'Przetłumacz na włoski:';
     correctAnswer = pair.it;
   }
   // Build answers: include correct answer and three random wrong answers
@@ -402,13 +403,26 @@ function newTranslationRound(container) {
   // Build UI
   const wrapper = document.createElement('div');
   wrapper.className = 'translation-game';
+
+  const flagsDiv = document.createElement('div');
+  flagsDiv.className = 'flags';
+  if (direction === 'it2pl') {
+    flagsDiv.innerHTML = '<span class="flag">🇮🇹</span><span class="arrow">→</span><span class="flag">🇵🇱</span>';
+  } else {
+    flagsDiv.innerHTML = '<span class="flag">🇵🇱</span><span class="arrow">→</span><span class="flag">🇮🇹</span>';
+  }
+  wrapper.appendChild(flagsDiv);
+
   const questionEl = document.createElement('div');
   questionEl.className = 'question';
-  // Use innerHTML because questionText may contain HTML (span)
-  // Use textContent because questionText no longer contains HTML. If
-  // you want to emphasize the word visually, you can style it via CSS.
-  questionEl.textContent = questionText;
+  questionEl.textContent = instructionText;
   wrapper.appendChild(questionEl);
+
+  const wordBox = document.createElement('div');
+  wordBox.className = 'word-box';
+  wordBox.textContent = questionWord;
+  wrapper.appendChild(wordBox);
+
   const answersDiv = document.createElement('div');
   answersDiv.className = 'answers';
   answers.forEach((ans) => {


### PR DESCRIPTION
## Summary
- Highlight translation word with dedicated box and directional flags
- Stack answers vertically for mobile-friendly play
- Style back button in grey and center it below game area
- Center translation word above answer choices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c4c05fd4083309c0330ace2f45576