### PR TITLE
Add speaker icons for Italian words in games

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,22 @@ footer {
   color: var(--color-red);
 }
 
+/* Reusable styling for Italian words with speaker icons */
+.it-word {
+  display: inline-flex;
+  align-items: center;
+}
+
+.speak-icon {
+  margin-left: 6px;
+  color: var(--color-green);
+  cursor: pointer;
+}
+
+.speak-icon:hover {
+  color: var(--color-red);
+}
+
 /* Category sections on recipe page */
 .category-section {
   margin-bottom: 40px;


### PR DESCRIPTION
## Summary
- add speech synthesis helpers and reusable Italian word component
- attach speaker icons across memory, ingredient, and translation games
- style speaker icon for consistent display
- ensure speaker icon uses Font Awesome 6 class so it renders correctly

## Testing
- `node --check js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c5356265c8330b90f43e3c868f1b8