### PR TITLE
Replace menu text with images and enhance ingredient game

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -176,16 +176,11 @@ h1, h2 {
   color: inherit;
 }
 
-.card .icon {
-  font-size: 2.5rem;
+.card-img {
+  width: 100%;
+  height: auto;
   margin-bottom: 10px;
-  color: var(--color-red);
-}
-
-.card h2 {
-  font-size: 1.4rem;
-  margin-bottom: 8px;
-  color: var(--color-green);
+  border-radius: 6px;
 }
 
 .card p {
@@ -471,6 +466,18 @@ summary::-webkit-details-marker {
   text-align: center;
 }
 
+.ingredient-game .dish-title-it {
+  text-align: center;
+  font-size: 1.6rem;
+  margin: 10px 0 4px;
+}
+
+.ingredient-game .dish-title-pl {
+  text-align: center;
+  font-style: italic;
+  margin-bottom: 15px;
+}
+
 .ingredient-game .options {
   display: flex;
   flex-wrap: wrap;
@@ -502,6 +509,13 @@ summary::-webkit-details-marker {
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.2s ease;
+}
+
+.ingredient-game .check-btn {
+  display: block;
+  margin: 20px auto 0;
+  font-size: 1.2rem;
+  padding: 12px 24px;
 }
 
 .ingredient-game .submit-btn:hover {

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -32,6 +32,7 @@
       <button id="runBtn">▶︎ Uruchom test</button>
       <button id="toggleErrorsBtn">Pokaż tylko błędy</button>
       <button id="exportCsvBtn">Eksportuj CSV</button>
+      <button id="reset-scores" class="reset-btn">Resetuj punkty</button>
       <label class="muted" style="display:flex; align-items:center; gap:6px;">
         <input type="checkbox" id="dupCheck"> Wykryj duplikaty ścieżek
       </label>
@@ -56,7 +57,8 @@
     </div>
   </div>
 
-  <!-- Skrypt diagnostyczny -->
+  <!-- Skrypty: zarządzanie punktami i diagnostyka -->
+  <script src="js/main.js"></script>
   <script src="js/diagnostics.js"></script>
   <script>
     fetch('data/recipes.json')

--- a/game.html
+++ b/game.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <header class="hero small-hero">
-      <img src="images/start1.jpg" alt="Grafika startowa Bella Cucina" class="hero-img" />
+      <img src="images/gry.jpg" alt="Gry" class="hero-img" />
     </header>
     <section class="page-title container">
       <h1>Gry</h1>

--- a/index.html
+++ b/index.html
@@ -34,22 +34,16 @@
       <section class="actions">
         <div class="card">
           <a href="recipes.html">
-            <div class="icon"><i class="fas fa-utensils"></i></div>
-            <h2>Przepisy</h2>
+            <img src="images/przepisy.jpg" alt="Przepisy" class="card-img" />
             <p>Odkrywaj dania i ucz się składników w dwóch językach.</p>
           </a>
         </div>
         <div class="card">
           <a href="game.html">
-            <div class="icon"><i class="fas fa-gamepad"></i></div>
-            <h2>Gry</h2>
+            <img src="images/gry.jpg" alt="Gry" class="card-img" />
             <p>Sprawdź swoją znajomość składników i przepisów w zabawnych grach.</p>
           </a>
         </div>
-      </section>
-
-      <section class="reset">
-        <button id="reset-scores" class="reset-btn">Resetuj punkty</button>
       </section>
     </main>
 

--- a/js/game.js
+++ b/js/game.js
@@ -424,10 +424,16 @@ function newIngredientRound(container) {
   wrapper.className = 'ingredient-game';
   const question = document.createElement('div');
   question.className = 'question';
-  question.textContent = 'Które składniki należą do przepisu: ';
-  question.appendChild(createItalianWordElement(recipe.italian_name));
-  question.appendChild(document.createTextNode(` / ${recipe.polish_name}?`));
+  question.textContent = 'Wybierz składniki do przepisu:';
   wrapper.appendChild(question);
+  const titleIt = document.createElement('div');
+  titleIt.className = 'dish-title-it';
+  titleIt.textContent = recipe.italian_name;
+  wrapper.appendChild(titleIt);
+  const titlePl = document.createElement('div');
+  titlePl.className = 'dish-title-pl';
+  titlePl.textContent = recipe.polish_name;
+  wrapper.appendChild(titlePl);
   const optsDiv = document.createElement('div');
   optsDiv.className = 'options';
   options.forEach((opt) => {
@@ -450,10 +456,10 @@ function newIngredientRound(container) {
   });
   wrapper.appendChild(optsDiv);
   const submit = document.createElement('button');
-  submit.className = 'submit-btn';
+  submit.className = 'submit-btn check-btn';
   submit.textContent = 'Sprawdź';
   submit.addEventListener('click', () => {
-    evaluateIngredientRound(wrapper, options);
+    evaluateIngredientRound(wrapper, options, recipe);
   });
   wrapper.appendChild(submit);
   container.innerHTML = '';
@@ -461,7 +467,8 @@ function newIngredientRound(container) {
   addExitButton(container);
 }
 
-function evaluateIngredientRound(wrapper, options) {
+function evaluateIngredientRound(wrapper, options, recipe) {
+  pronounceItalian(recipe.italian_name);
   let pointsThisRound = 0;
   const optionEls = wrapper.querySelectorAll('.option');
   optionEls.forEach((el) => {

--- a/recipes.html
+++ b/recipes.html
@@ -15,7 +15,7 @@
   </head>
   <body>
     <header class="hero small-hero">
-      <img src="images/start1.jpg" alt="Grafika startowa Bella Cucina" class="hero-img" />
+      <img src="images/przepisy.jpg" alt="Przepisy" class="hero-img" />
     </header>
     <section class="page-title container">
       <h1>Przepisy</h1>


### PR DESCRIPTION
## Summary
- Use image-based buttons on home page and remove reset control
- Move score reset to diagnostics and swap hero images on subpages
- Center and enlarge ingredient game title and check button with Italian TTS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_689c6db850fc83308de5877c50a54513