### PR TITLE
Use images for menu buttons and enhance ingredient game

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -192,6 +192,12 @@ h1, h2 {
   font-size: 0.95rem;
   color: var(--text-dark);
 }
+.card img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 10px;
+}
 
 /* Reset button */
 .reset {
@@ -494,19 +500,31 @@ summary::-webkit-details-marker {
 }
 
 .ingredient-game .submit-btn {
-  margin-top: 15px;
+  margin: 20px auto;
+  display: block;
   background-color: var(--color-green);
   color: var(--color-white);
   border: none;
-  padding: 8px 16px;
+  padding: 12px 24px;
+  font-size: 1.1rem;
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.2s ease;
 }
-
 .ingredient-game .submit-btn:hover {
   background-color: #007735;
 }
+.ingredient-game .recipe-title-it {
+  text-align: center;
+  font-size: 1.5rem;
+  margin-bottom: 4px;
+}
+.ingredient-game .recipe-title-pl {
+  text-align: center;
+  font-style: italic;
+  margin-bottom: 10px;
+}
+
 
 /* Translation game */
 .translation-game {

--- a/diagnostics.html
+++ b/diagnostics.html
@@ -32,6 +32,7 @@
       <button id="runBtn">▶︎ Uruchom test</button>
       <button id="toggleErrorsBtn">Pokaż tylko błędy</button>
       <button id="exportCsvBtn">Eksportuj CSV</button>
+      <button id="reset-scores" class="reset-btn">Resetuj punkty</button>
       <label class="muted" style="display:flex; align-items:center; gap:6px;">
         <input type="checkbox" id="dupCheck"> Wykryj duplikaty ścieżek
       </label>
@@ -57,6 +58,7 @@
   </div>
 
   <!-- Skrypt diagnostyczny -->
+  <script src="js/main.js"></script>
   <script src="js/diagnostics.js"></script>
   <script>
     fetch('data/recipes.json')

--- a/game.html
+++ b/game.html
@@ -15,11 +15,10 @@
   </head>
   <body>
     <header class="hero small-hero">
-      <img src="images/start1.jpg" alt="Grafika startowa Bella Cucina" class="hero-img" />
+      <img src="images/gry_big.jpg" alt="Gry" class="hero-img" />
     </header>
     <section class="page-title container">
       <h1>Gry</h1>
-      <p class="tagline">Rywalizuj, ucz się i baw dobrze!</p>
     </section>
 
     <main class="container">

--- a/index.html
+++ b/index.html
@@ -34,22 +34,14 @@
       <section class="actions">
         <div class="card">
           <a href="recipes.html">
-            <div class="icon"><i class="fas fa-utensils"></i></div>
-            <h2>Przepisy</h2>
-            <p>Odkrywaj dania i ucz się składników w dwóch językach.</p>
+            <img src="images/przepisy.jpg" alt="Przepisy" />
           </a>
         </div>
         <div class="card">
           <a href="game.html">
-            <div class="icon"><i class="fas fa-gamepad"></i></div>
-            <h2>Gry</h2>
-            <p>Sprawdź swoją znajomość składników i przepisów w zabawnych grach.</p>
+            <img src="images/gry.jpg" alt="Gry" />
           </a>
         </div>
-      </section>
-
-      <section class="reset">
-        <button id="reset-scores" class="reset-btn">Resetuj punkty</button>
       </section>
     </main>
 

--- a/js/game.js
+++ b/js/game.js
@@ -422,11 +422,17 @@ function newIngredientRound(container) {
   // Create game wrapper
   const wrapper = document.createElement('div');
   wrapper.className = 'ingredient-game';
+  const titleIt = document.createElement('div');
+  titleIt.className = 'recipe-title-it';
+  titleIt.textContent = recipe.italian_name;
+  wrapper.appendChild(titleIt);
+  const titlePl = document.createElement('div');
+  titlePl.className = 'recipe-title-pl';
+  titlePl.textContent = recipe.polish_name;
+  wrapper.appendChild(titlePl);
   const question = document.createElement('div');
   question.className = 'question';
-  question.textContent = 'Które składniki należą do przepisu: ';
-  question.appendChild(createItalianWordElement(recipe.italian_name));
-  question.appendChild(document.createTextNode(` / ${recipe.polish_name}?`));
+  question.textContent = 'Które składniki należą do przepisu?';
   wrapper.appendChild(question);
   const optsDiv = document.createElement('div');
   optsDiv.className = 'options';
@@ -453,7 +459,7 @@ function newIngredientRound(container) {
   submit.className = 'submit-btn';
   submit.textContent = 'Sprawdź';
   submit.addEventListener('click', () => {
-    evaluateIngredientRound(wrapper, options);
+    evaluateIngredientRound(wrapper, options, recipe.italian_name);
   });
   wrapper.appendChild(submit);
   container.innerHTML = '';
@@ -461,7 +467,8 @@ function newIngredientRound(container) {
   addExitButton(container);
 }
 
-function evaluateIngredientRound(wrapper, options) {
+function evaluateIngredientRound(wrapper, options, italianName) {
+  pronounceItalian(italianName);
   let pointsThisRound = 0;
   const optionEls = wrapper.querySelectorAll('.option');
   optionEls.forEach((el) => {

--- a/recipes.html
+++ b/recipes.html
@@ -15,11 +15,10 @@
   </head>
   <body>
     <header class="hero small-hero">
-      <img src="images/start1.jpg" alt="Grafika startowa Bella Cucina" class="hero-img" />
+      <img src="images/przepisy_big.jpg" alt="Przepisy" class="hero-img" />
     </header>
     <section class="page-title container">
       <h1>Przepisy</h1>
-      <p class="tagline">Ponad sto dań na każdą okazję</p>
     </section>
 
     <main class="container">


### PR DESCRIPTION
## Summary
- Replace main menu text buttons with graphic buttons and remove reset button
- Move reset control to diagnostics and switch subpage hero images
- Center and enlarge ingredient game titles and controls with Italian speech on check

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c741d368c8330853575c25a7384f7