### PR TITLE
Add floating menu and image-based game buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,12 +20,37 @@ body {
   background-color: var(--color-beige);
   color: var(--text-dark);
   line-height: 1.6;
+  padding-top: 60px;
 }
 
 h1, h2 {
   font-family: 'Georgia', serif;
   text-transform: uppercase;
   letter-spacing: 1px;
+}
+
+.top-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: var(--color-beige);
+  box-shadow: 0 2px 5px var(--card-shadow);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+
+.top-nav a {
+  text-decoration: none;
+  color: var(--text-dark);
+  font-weight: bold;
+  padding: 10px 0;
+}
+
+.top-nav a:hover {
+  color: var(--color-red);
 }
 
 /* Hero section now contains only an image. Image scales with viewport */
@@ -406,9 +431,8 @@ summary::-webkit-details-marker {
   background-color: var(--color-white);
   border-radius: 10px;
   box-shadow: 0 2px 5px var(--card-shadow);
-  padding: 20px;
   width: 200px;
-  text-align: center;
+  overflow: hidden;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -418,15 +442,10 @@ summary::-webkit-details-marker {
   box-shadow: 0 4px 10px var(--card-shadow);
 }
 
-.game-card .icon {
-  font-size: 2rem;
-  margin-bottom: 10px;
-  color: var(--color-red);
-}
-
-.game-card h3 {
-  font-size: 1.2rem;
-  color: var(--color-green);
+.game-card img {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 /* Memory game grid */

--- a/game.html
+++ b/game.html
@@ -14,17 +14,16 @@
     />
   </head>
   <body>
+    <nav class="top-nav">
+      <a href="index.html">Strona główna</a>
+      <a href="recipes.html">Przepisy</a>
+      <a href="game.html">Gry</a>
+    </nav>
     <header class="hero small-hero">
       <img src="images/gry_big.jpg" alt="Gry" class="hero-img" />
     </header>
-    <section class="page-title container">
-      <h1>Gry</h1>
-    </section>
 
     <main class="container">
-      <div class="back-link">
-        <a href="index.html"><i class="fas fa-arrow-left"></i> Powrót</a>
-      </div>
       <section class="game-controls">
         <div class="player-select">
           <div id="player-options"></div>
@@ -35,16 +34,13 @@
         </div>
         <div class="game-select">
           <div class="game-card" data-game="memory">
-            <div class="icon"><i class="fas fa-brain"></i></div>
-            <h3>Gra pamięciowa</h3>
+            <img src="images/memory_game.jpg" alt="Gra pamięciowa" />
           </div>
           <div class="game-card" data-game="ingredients">
-            <div class="icon"><i class="fas fa-carrot"></i></div>
-            <h3>Dobierz składniki</h3>
+            <img src="images/skladniki_game.jpg" alt="Dobierz składniki" />
           </div>
           <div class="game-card" data-game="translation">
-            <div class="icon"><i class="fas fa-language"></i></div>
-            <h3>Tłumaczenie</h3>
+            <img src="images/tlumacz_game.jpg" alt="Tłumaczenie" />
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,11 @@
     />
   </head>
   <body>
+    <nav class="top-nav">
+      <a href="index.html">Strona główna</a>
+      <a href="recipes.html">Przepisy</a>
+      <a href="game.html">Gry</a>
+    </nav>
     <header class="hero">
       <img src="images/start1.jpg" alt="Grafika startowa Bella Cucina" class="hero-img" />
     </header>

--- a/recipes.html
+++ b/recipes.html
@@ -14,18 +14,17 @@
     />
   </head>
   <body>
+    <nav class="top-nav">
+      <a href="index.html">Strona główna</a>
+      <a href="recipes.html">Przepisy</a>
+      <a href="game.html">Gry</a>
+    </nav>
     <header class="hero small-hero">
       <img src="images/przepisy_big.jpg" alt="Przepisy" class="hero-img" />
     </header>
-    <section class="page-title container">
-      <h1>Przepisy</h1>
-    </section>
 
     <main class="container">
       <section class="controls">
-        <div class="back-link">
-          <a href="index.html"><i class="fas fa-arrow-left"></i> Powrót</a>
-        </div>
         <div class="filter-row">
           <input
             type="text"


### PR DESCRIPTION
## Summary
- Replace game selection text with graphics and remove back links.
- Add fixed top navigation menu across pages and strip textual page headings.
- Update styles for new navigation and image-only game cards.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c7c80cec08330813480bcb9804465