### PR TITLE
feat: reset player registry from diagnostics

### DIFF
--- a/js/diagnostics.js
+++ b/js/diagnostics.js
@@ -12,6 +12,11 @@
   let onlyErrors = false;
   let lastRows = []; // pamiętamy wyniki do eksportu
 
+  // Clear all registered players when diagnostics loads
+  if (typeof window.resetPlayers === 'function') {
+    window.resetPlayers();
+  }
+
   function sanitizeIssues(path) {
     if (!path) return [];
     const issues = [];

--- a/js/main.js
+++ b/js/main.js
@@ -71,6 +71,21 @@ function resetScores() {
   renderScoreboard();
 }
 
+// Completely remove all players from the registry
+function resetPlayers() {
+  memoryScores = {};
+  if (storageAvailable) {
+    try {
+      localStorage.removeItem('bellaScores');
+      localStorage.removeItem('bellaCurrentPlayer');
+    } catch (e) {
+      console.error('Błąd kasowania graczy z localStorage:', e);
+      storageAvailable = false;
+    }
+  }
+  renderScoreboard();
+}
+
 // Add a new player with zero points
 function addPlayer(name) {
   const scores = loadScores();


### PR DESCRIPTION
## Summary
- add resetPlayers helper to wipe all saved players
- clear player registry automatically when diagnostics page loads

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c7d2a4870833094e367f27cd58c41