### PR TITLE
feat: reset player registry from diagnostics

### DIFF
--- a/diagnostics.html
+++ b/diagnostics.html
@@ -33,6 +33,7 @@
       <button id="toggleErrorsBtn">Pokaż tylko błędy</button>
       <button id="exportCsvBtn">Eksportuj CSV</button>
       <button id="reset-scores" class="reset-btn">Resetuj punkty</button>
+      <button id="reset-players" class="reset-btn">Kasuj Rejestr Graczy</button>
       <label class="muted" style="display:flex; align-items:center; gap:6px;">
         <input type="checkbox" id="dupCheck"> Wykryj duplikaty ścieżek
       </label>

--- a/js/main.js
+++ b/js/main.js
@@ -71,6 +71,21 @@ function resetScores() {
   renderScoreboard();
 }
 
+// Completely remove all players from the registry
+function resetPlayers() {
+  memoryScores = {};
+  if (storageAvailable) {
+    try {
+      localStorage.removeItem('bellaScores');
+      localStorage.removeItem('bellaCurrentPlayer');
+    } catch (e) {
+      console.error('Błąd kasowania graczy z localStorage:', e);
+      storageAvailable = false;
+    }
+  }
+  renderScoreboard();
+}
+
 // Add a new player with zero points
 function addPlayer(name) {
   const scores = loadScores();
@@ -89,6 +104,15 @@ document.addEventListener('DOMContentLoaded', () => {
     resetBtn.addEventListener('click', () => {
       if (confirm('Czy na pewno chcesz zresetować punkty?')) {
         resetScores();
+      }
+    });
+  }
+
+  const resetPlayersBtn = document.getElementById('reset-players');
+  if (resetPlayersBtn) {
+    resetPlayersBtn.addEventListener('click', () => {
+      if (confirm('Czy na pewno chcesz skasować rejestr graczy?')) {
+        resetPlayers();
       }
     });
   }


### PR DESCRIPTION
## Summary
- add a dedicated button on the diagnostics page to clear registered players
- wire the new button to `resetPlayers` and stop wiping players automatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c7d2a4870833094e367f27cd58c41