### PR TITLE
Show recipe image under title with max width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -742,16 +742,18 @@ summary::-webkit-details-marker {
   margin-bottom: 6px;
 }
 
-/* Recipe photo displayed beneath the ingredients list.  We set a
-   responsive width so the image scales with the container. A border
-   radius softens the corners and a subtle box shadow helps it stand
-   out against the white card. */
+/* Recipe photo displayed at the top of the expanded recipe, right below
+   the title. The image scales with the container but never exceeds
+   600px in width. A border radius softens the corners and a subtle box
+   shadow helps it stand out against the white card. */
 .recipe-photo {
   width: 100%;
+  max-width: 600px;
   height: auto;
   border-radius: 6px;
-  margin-top: 15px;
+  margin: 15px auto;
   box-shadow: 0 2px 4px var(--card-shadow);
+  display: block;
 }
 
 /* Source attribution shown under each recipe photo. Use a small

--- a/js/recipes.js
+++ b/js/recipes.js
@@ -213,6 +213,24 @@ function displayRecipes() {
 
       const contentDiv = document.createElement('div');
       contentDiv.className = 'ingredients-list';
+
+      // If the recipe has a photo defined, display it at the top right below the title.
+      // We also show a small attribution line referencing the source of the image.
+      if (recipe.image) {
+        const imgEl = document.createElement('img');
+        imgEl.src = recipe.image;
+        imgEl.alt = recipe.italian_name;
+        imgEl.className = 'recipe-photo';
+        contentDiv.appendChild(imgEl);
+        // Add source line if provided
+        if (recipe.source) {
+          const sourceEl = document.createElement('div');
+          sourceEl.className = 'image-source';
+          sourceEl.textContent = recipe.source;
+          contentDiv.appendChild(sourceEl);
+        }
+      }
+
       const list = document.createElement('ul');
       recipe.ingredients.forEach((ing) => {
         const li = document.createElement('li');
@@ -270,22 +288,6 @@ function displayRecipes() {
         contentDiv.appendChild(descDiv);
       }
 
-      // If the recipe has a photo defined, display it under the description.
-      // We also show a small attribution line referencing the source of the image.
-      if (recipe.image) {
-        const imgEl = document.createElement('img');
-        imgEl.src = recipe.image;
-        imgEl.alt = recipe.italian_name;
-        imgEl.className = 'recipe-photo';
-        contentDiv.appendChild(imgEl);
-        // Add source line if provided
-        if (recipe.source) {
-          const sourceEl = document.createElement('div');
-          sourceEl.className = 'image-source';
-          sourceEl.textContent = recipe.source;
-          contentDiv.appendChild(sourceEl);
-        }
-      }
       detailsEl.appendChild(contentDiv);
 
       // Add toggle event to pronounce the recipe title when opened


### PR DESCRIPTION
## Summary
- Move recipe photo to top of expanded recipe section right beneath the title
- Restrict recipe images to max 600px width and center them

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c932750408330ae28d11d99e34b86